### PR TITLE
catkin_linting neo_driver

### DIFF
--- a/cob_scan_unifier/CMakeLists.txt
+++ b/cob_scan_unifier/CMakeLists.txt
@@ -9,10 +9,9 @@ endif()
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-  laser_geometry
   roscpp
-  rospy
   sensor_msgs
+  laser_geometry
   tf
 )
 
@@ -27,16 +26,11 @@ find_package(catkin REQUIRED COMPONENTS
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  INCLUDE_DIRS 
-    include
-#  LIBRARIES cob_scan_unifier
   CATKIN_DEPENDS 
-    laser_geometry 
-    roscpp 
-    rospy 
-    sensor_msgs 
+    roscpp
+    laser_geometry
+    sensor_msgs
     tf
-#  DEPENDS system_lib
 )
 
 ###########
@@ -47,16 +41,12 @@ catkin_package(
 ## Your package locations should be listed before other locations
 # include_directories(include)
 include_directories(
-  include/cob_scan_unifier
+  include
   ${catkin_INCLUDE_DIRS}
 )
 
 ## Declare a cpp executable
 add_executable(scan_unifier_node src/scan_unifier_node.cpp)
-
-## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
-add_dependencies(scan_unifier_node cob_scan_unifier_gencpp)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(scan_unifier_node
@@ -83,5 +73,4 @@ install(TARGETS scan_unifier_node
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
-
 

--- a/cob_scan_unifier/package.xml
+++ b/cob_scan_unifier/package.xml
@@ -14,15 +14,13 @@
 
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>laser_geometry</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>laser_geometry</build_depend>
   <build_depend>tf</build_depend>
-  <run_depend>laser_geometry</run_depend>
   <run_depend>roscpp</run_depend>
-  <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>laser_geometry</run_depend>
   <run_depend>tf</run_depend>
 
 

--- a/cob_scan_unifier/src/scan_unifier_node.cpp
+++ b/cob_scan_unifier/src/scan_unifier_node.cpp
@@ -56,7 +56,7 @@
 *
 ****************************************************************/
 
-#include <scan_unifier_node.h>
+#include <cob_scan_unifier/scan_unifier_node.h>
 
 // constructor
 scan_unifier_node::scan_unifier_node()

--- a/neo_msgs/CMakeLists.txt
+++ b/neo_msgs/CMakeLists.txt
@@ -9,30 +9,30 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
- ##Generate messages in the 'msg' folder
- add_message_files(
-   FILES
-    	EmergencyStopState.msg
-	GyroBoard.msg
-	IOAnalogIn.msg
-	IOOut.msg
-	IRSensors.msg
-	Keypad.msg
-	LCDOutput.msg
-	RadarBoard.msg
-	USBoard.msg
-	PowerState.msg
-	PowerBoardState.msg
- )
+##Generate messages in the 'msg' folder
+add_message_files(
+  FILES
+  EmergencyStopState.msg
+  GyroBoard.msg
+  IOAnalogIn.msg
+  IOOut.msg
+  IRSensors.msg
+  Keypad.msg
+  LCDOutput.msg
+  RadarBoard.msg
+  USBoard.msg
+  PowerState.msg
+  PowerBoardState.msg
+)
 
 
- generate_messages(
-   DEPENDENCIES
-   std_msgs
+generate_messages(
+  DEPENDENCIES
+  std_msgs
  )
 
 catkin_package(
-  CATKIN_DEPENDS message_runtime
+  CATKIN_DEPENDS std_msgs message_runtime
 )
 
 

--- a/neo_platformctrl_diff/CMakeLists.txt
+++ b/neo_platformctrl_diff/CMakeLists.txt
@@ -30,7 +30,7 @@ find_package(catkin REQUIRED COMPONENTS
 ###################################
 
 catkin_package(
-    CATKIN_DEPENDS roscpp rostest std_msgs tf nav_msgs sensor_msgs
+    CATKIN_DEPENDS roscpp rostest std_msgs tf nav_msgs sensor_msgs trajectory_msgs
     INCLUDE_DIRS common/include
     LIBRARIES ${PROJECT_NAME}
 )
@@ -63,4 +63,11 @@ install(TARGETS ${PROJECT_NAME} neo_platformctrl_diff_node
     ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+install(DIRECTORY common/include/
+ DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+ FILES_MATCHING PATTERN "*.h"
+ PATTERN ".svn" EXCLUDE
 )

--- a/neo_platformctrl_mecanum/CMakeLists.txt
+++ b/neo_platformctrl_mecanum/CMakeLists.txt
@@ -30,7 +30,7 @@ find_package(catkin REQUIRED COMPONENTS
 ###################################
 
 catkin_package(
-    CATKIN_DEPENDS std_msgs tf nav_msgs sensor_msgs
+    CATKIN_DEPENDS std_msgs tf nav_msgs sensor_msgs trajectory_msgs
     INCLUDE_DIRS common/include
     LIBRARIES ${PROJECT_NAME}
 )
@@ -59,4 +59,15 @@ target_link_libraries(neo_platformctrl_mecanum_node ${catkin_LIBRARIES})
 #############
 
 ## Mark executables and/or libraries for installation
+install(TARGETS ${PROJECT_NAME} neo_platformctrl_mecanum_node
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
+## Mark cpp header files for installation
+install(DIRECTORY common/include/
+ DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+ FILES_MATCHING PATTERN "*.h"
+ PATTERN ".svn" EXCLUDE
+)

--- a/neo_relayboard/CMakeLists.txt
+++ b/neo_relayboard/CMakeLists.txt
@@ -6,7 +6,6 @@ project(neo_relayboard)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   roscpp
-  rospy
   sensor_msgs
   std_msgs
   trajectory_msgs
@@ -15,9 +14,9 @@ find_package(catkin REQUIRED COMPONENTS
 
 
 catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES neo_relayboard
-#  CATKIN_DEPENDS message_runtime
+  INCLUDE_DIRS common/include
+  LIBRARIES ${PROJECT_NAME} SerialIO
+  CATKIN_DEPENDS roscpp sensor_msgs std_msgs trajectory_msgs neo_msgs
 #  DEPENDS system_lib
 )
 
@@ -44,6 +43,19 @@ add_dependencies(neo_relayboard_node ${PROJECT_NAME}_gencpp)
 ## Install ##
 #############
 
+## Mark executables and/or libraries for installation
+install(TARGETS ${PROJECT_NAME} SerialIO neo_relayboard_node
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+install(DIRECTORY common/include/
+ DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+ FILES_MATCHING PATTERN "*.h"
+ PATTERN ".svn" EXCLUDE
+)
 
 
 #############

--- a/neo_relayboard/package.xml
+++ b/neo_relayboard/package.xml
@@ -11,14 +11,12 @@
   
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>trajectory_msgs</build_depend>
   <build_depend>neo_msgs</build_depend>
 
   <run_depend>roscpp</run_depend>
-  <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>trajectory_msgs</run_depend>

--- a/neo_relayboard/src/neo_relayboard_node.cpp
+++ b/neo_relayboard/src/neo_relayboard_node.cpp
@@ -15,7 +15,7 @@ int main(int argc, char** argv)
 		node.requestBoardStatus();
 		node.sendEmergencyStopStates();
 		node.sendAnalogIn();
-		node.sendRelayBoardDigOut();
+		//node.sendRelayBoardDigOut();
 		node.sendDriveStates();
 		node.sendGyroBoard();
 		node.sendRadarBoard();

--- a/neo_watchdogs/CMakeLists.txt
+++ b/neo_watchdogs/CMakeLists.txt
@@ -26,11 +26,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES neo_watchdogs
-  CATKIN_DEPENDS 
-  neo_relayboard 
-  roscpp
-  move_base_msgs
-  neo_msgs
+  CATKIN_DEPENDS neo_relayboard roscpp move_base_msgs neo_msgs
 #  DEPENDS system_lib
 )
 
@@ -41,7 +37,6 @@ catkin_package(
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
-
 
 add_executable(watch_power src/watch_power.cpp)
 add_executable(watch_scanner_stop src/watch_scanner_stop.cpp)
@@ -59,6 +54,13 @@ target_link_libraries(watch_temp
 #############
 ## Install ##
 #############
+
+## Mark executables and/or libraries for installation
+install(TARGETS watch_power watch_scanner_stop watch_temp
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 
 #############


### PR DESCRIPTION
Scrolling through debbuild for indigo, I found that some neobotix packages are not compiling...see [here](http://www.ros.org/debbuild/indigo.html?q=neo)

This PR should fix some of the problems the buildfarm is having when trying to compile neo_driver.
The issue reported in #4 is "resolved" by commenting the according [line](https://github.com/ipa-fxm/neo_driver/blob/catkin_linting_indigo/neo_relayboard/src/neo_relayboard_node.cpp#L18)...

However, in case you are trying to release neo_driver into indigo, there will be a name conflict with the ```cob_scan_unifier``` package from [cob_navigation](https://github.com/ipa320/cob_navigation)...

Hope this PR helps you getting the debbuild issues fixed!